### PR TITLE
The audit query use ActiveRecord::Base::all() which is deprecated

### DIFF
--- a/app/models/audit_query.rb
+++ b/app/models/audit_query.rb
@@ -88,14 +88,13 @@ class AuditQuery < Query
   def audits(options={})
     order_option = [group_by_sort_order, options[:order]].flatten.reject(&:blank?)
 
-    audits = Audit.where(options[:conditions]).all(
-      :include => [:project, :changeset, :user],
-      :conditions => statement,
-      :order => order_option,
-      :joins => joins_for_order_statement(order_option.join(',')),
-      :limit  => options[:limit],
-      :offset => options[:offset]
-    )
+    audits = Audit
+      .joins(joins_for_order_statement(order_option.join(',')))
+      .eager_load([:project, :changeset, :user])
+      .where(options[:conditions])
+      .order(order_option)
+      .limit(options[:limit])
+      .offset(options[:offset])
 
     audits
   rescue ::ActiveRecord::StatementInvalid => e


### PR DESCRIPTION
Ref #56 - An internal error is generated when view the audits page on Redmine 3
