### PR TITLE
[Ref #81] Links in the notification emails are invalid

### DIFF
--- a/lib/code_audit/patches/mailer_patch.rb
+++ b/lib/code_audit/patches/mailer_patch.rb
@@ -18,7 +18,7 @@ module CodeAudit
         @author = audit.author
         @changeset = audit.changeset
         @repository = @changeset.repository
-        @audit_url = project_audit_path(@project, @audit)
+        @audit_url = url_for(:controller => 'audits', :action => 'show', :project => @project, :id => @audit)
         recipients = audit.recipients
         cc = audit.watcher_recipients - recipients
 


### PR DESCRIPTION
Update the URL generation to have absolute path (based on the Redmine Mailer class).
